### PR TITLE
Add app icon for main window

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,8 @@ function openMainWindow () {
       backgroundColor: '#444',
       webPreferences: {
         experimentalFeatures: true
-      }
+      },
+      icon: './ferment-logo.png'
     })
     windows.main.setSheetOffset(40)
     windows.main.on('closed', function () {


### PR DESCRIPTION
This commit adds the `icon` parameter to `openWindow` inside the `openMainWindow` function.
This way on Linux  the ferment logo is shown when launching with `npm start` - otherwise it just shows a grey box with a question mark inside on Ubuntu. 

I did not move the logo to a different location, however, it might be better to have a logo inside `assets/images` or something similar.

Impressive piece of software you build, I'm already in love and hope more artists will join!
